### PR TITLE
DM-2917: obs_cfht unit tests are broken

### DIFF
--- a/CALIB/bias/08Bm04.bias.0.36.00.fits
+++ b/CALIB/bias/08Bm04.bias.0.36.00.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8617f5e8f0706d790caa9db6832065360727f8fd31239cb29de497a1cbb8d33
-size 707636160

--- a/CALIB/bias/08Bm04.bias.0.36.00.fits.fz
+++ b/CALIB/bias/08Bm04.bias.0.36.00.fits.fz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:884867d496490901281fe95a37b007aad06d71cea5b5e52aa881aa6d92304bd7
+size 102666240

--- a/CALIB/calibRegistry.sqlite3
+++ b/CALIB/calibRegistry.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c05c2f639261a9bdeb2f3f058bc57b122dc0fc51f848c7e5cb59386d7f3dd2a2
-size 4084736
+oid sha256:edbd7ffa2b52de79da14cc72993ecb222f5b4274ff7a60db06e8c24a4f2bfa52
+size 4101120

--- a/CALIB/flat/i2/08Bm04.flat.i2.36.02.fits
+++ b/CALIB/flat/i2/08Bm04.flat.i2.36.02.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47b9747dbfc252531b0861765249dcb6a0ae1e31be817f0562d45e905a973049
-size 707754240

--- a/CALIB/flat/i2/08Bm04.flat.i2.36.02.fits.fz
+++ b/CALIB/flat/i2/08Bm04.flat.i2.36.02.fits.fz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24a3ea5117a4f9a7f50cc6ca7e418024d4b9b64b008a1b580fc1282d22bc6e05
+size 388146240

--- a/CALIB/fringe/08Bm04.fringe.i2.36.00.fits
+++ b/CALIB/fringe/08Bm04.fringe.i2.36.00.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdadbd685332afecf1dcd35c1583d27309799e05b808625a72c50f498ffdfc8a
-size 707970240

--- a/CALIB/fringe/08Bm04.fringe.i2.36.00.fits.fz
+++ b/CALIB/fringe/08Bm04.fringe.i2.36.00.fits.fz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2a21e7f72dc34de2699ffde36fd897c63b328912f9dd396aa6fb5a2a29b74d4
+size 434597760


### PR DESCRIPTION
Compress calibration FITS files.  Update calibRegistry to match new names (e.g., with additional ".fz").

Passes `obs_cfht` tests with

tickets/DM-4732    (daf_butlerUtils)
tickets/DM-2917    (testdata_cfht; this one)
